### PR TITLE
Remove rolling mean for PV

### DIFF
--- a/india_forecast_app/models/pvnet/model.py
+++ b/india_forecast_app/models/pvnet/model.py
@@ -123,10 +123,12 @@ class PVNetModel:
             ]
         )  # index 3 is the 50th percentile)
 
-        # smooth with a 1 hour rolling window
-        values_df["forecast_power_kw"] = (
-            values_df["forecast_power_kw"].rolling(4, min_periods=1).mean().astype(int)
-        )
+        if self.asset_type=="wind":
+            # Smooth with a 1 hour rolling window
+            # Only smooth the wind else we introduce too much of a lag in the solar going up and down
+            values_df["forecast_power_kw"] = (
+                values_df["forecast_power_kw"].rolling(4, min_periods=1).mean().astype(int)
+            )
 
         # remove any negative values
         values_df["forecast_power_kw"] = values_df["forecast_power_kw"].clip(lower=0.0)


### PR DESCRIPTION
# Pull Request

## Description

In production, the solar values look like they are lagged by an hour compared to actual. The rolling mean currently in the app would cause this effect.

By example:

When the forecast is going up the rolling mean systematically decreases all the values
```
da = xr.DataArray(
    np.linspace(0, 11, num=12),
    coords=[
        pd.date_range(
            "2024-01-01 00:00",
            periods=12,
            freq="15T",
        )
    ],
    dims="time",
)
da
```
```
<xarray.DataArray (time: 12)>
array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10., 11.])
Coordinates:
  * time     (time) datetime64[ns] 2024-01-01 ... 2024-01-01T02:45:00
```

```
da.rolling(time=4,  min_periods=1).mean()
```
```
array([0. , 0.5, 1. , 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5])
```
Also when the forecast is going down the rolling mean will systematically increase all the values.

