### PR TITLE
Revert "fix(pvnet-utils): variable->variables"

### DIFF
--- a/india_forecast_app/models/pvnet/utils.py
+++ b/india_forecast_app/models/pvnet/utils.py
@@ -90,15 +90,15 @@ def process_and_cache_nwp(source_nwp_path: str, dest_nwp_path: str):
             ds[v].encoding.clear()
 
     # Rename t variable to t2m
-    variables = list(ds.variables.values)
+    variables = list(ds.variable.values)
     new_variables = []
     for var in variables:
         if "t" == var:
             new_variables.append("t2m")
-            log.debug(f"Renamed t to t2m in NWP data {ds.variables.values}")
+            log.debug(f"Renamed t to t2m in NWP data {ds.variable.values}")
         elif "clt" == var:
             new_variables.append("tcc")
-            log.debug(f"Renamed clt to tcc in NWP data {ds.variables.values}")
+            log.debug(f"Renamed clt to tcc in NWP data {ds.variable.values}")
         else:
             new_variables.append(var)
     ds.__setitem__("variable", new_variables)


### PR DESCRIPTION
This reverts commit 038d8c3922a42d3eb431273aafd72a2706090c51.

# Pull Request

## Description

Reverse fix due to odd nwp format

## How Has This Been Tested?

CI tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
