### PR TITLE
un normalize sun elevation

### DIFF
--- a/india_forecast_app/models/pvnet/utils.py
+++ b/india_forecast_app/models/pvnet/utils.py
@@ -7,6 +7,7 @@ import numpy as np
 import xarray as xr
 import yaml
 from ocf_datapipes.batch import BatchKey
+from ocf_datapipes.utils.consts import ELEVATION_MEAN, ELEVATION_STD
 
 from .consts import (
     nwp_ecmwf_path,
@@ -173,6 +174,9 @@ def set_night_time_zeros(batch, preds, sun_elevation_limit=0.0):
     sun_elevation = batch[key]
     if not isinstance(sun_elevation, np.ndarray):
         sun_elevation = sun_elevation.detach().cpu().numpy()
+
+    # un normalize elevation
+    sun_elevation = sun_elevation * ELEVATION_STD + ELEVATION_MEAN
 
     # expand dimension from (1,197) to (1,197,7), 7 is due to the number plevels
     n_plevels = preds.shape[2]


### PR DESCRIPTION
# Pull Request

## Description

Make sure sun elevation is not normalized, similar to uk-pvnet-app

## How Has This Been Tested?

CI tests

- [x] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
