### PR TITLE
Issue/adjuster minutes

### DIFF
--- a/india_forecast_app/models/all_models.yaml
+++ b/india_forecast_app/models/all_models.yaml
@@ -39,6 +39,7 @@ models:
     version: 20e7c3af76664ee2ac0e1502801749825ab8ed1f
     client: ad
     asset_type: pv
+    adjuster_average_minutes: 15
   # this is just a dummy one
   - name: dummy
     type: dummy

--- a/india_forecast_app/models/pydantic_models.py
+++ b/india_forecast_app/models/pydantic_models.py
@@ -28,6 +28,13 @@ class Model(BaseModel):
     asset_type: str = Field(
         "pv", title="Asset Type", description="The type of asset the model is for (pv or wind)"
     )
+    adjuster_average_minutes: int = Field(
+        60,
+        title="Average Minutes",
+        description="The number of minutes that results are average over when calculating adjuster values. "
+                    "For solar site with regular data, 15 should be used. "
+                    "For wind sites, 60 minutes should be used.",
+    )
 
 
 class Models(BaseModel):

--- a/tests/test_adjuster.py
+++ b/tests/test_adjuster.py
@@ -25,6 +25,29 @@ def test_get_me_values(db_session, sites, generation_db_values, forecasts):
     assert me_df["me_kw"].sum() != 0
     assert me_df["horizon_minutes"][0] == 0
     assert me_df["horizon_minutes"][1] == 15
+    assert me_df["me_kw"][90] != 0
+
+
+def test_get_me_values_15(db_session, sites, generation_db_values, forecasts):
+    """Check ME results are found"""
+
+    hour = pd.Timestamp(datetime.now()).hour
+    me_df_15 = get_me_values(
+        db_session, hour, site_uuid=sites[0].site_uuid, ml_model_name="test", average_minutes=15
+    )
+    me_df_60 = get_me_values(
+        db_session, hour, site_uuid=sites[0].site_uuid, ml_model_name="test", average_minutes=60
+    )
+
+    assert len(me_df_15) != 0
+    assert len(me_df_15) == 96
+    assert me_df_15["me_kw"].sum() != 0
+    assert me_df_15["horizon_minutes"][0] == 0
+    assert me_df_15["horizon_minutes"][1] == 15
+
+    # make sure the 15 and 60 are differnet values
+    assert me_df_15["horizon_minutes"][90] == me_df_60["horizon_minutes"][90]
+    assert me_df_15["me_kw"][90] != me_df_60["me_kw"][90]
 
 
 def test_get_me_values_no_generation(db_session, sites, forecasts):


### PR DESCRIPTION
# Pull Request

## Description

-  add method to choose how we group the adjuster values by.
- set ad sites to use 15 minutes
- keep ruvnl sites to be 60 minutes grouping due to sprase data sometimes, and wind needing to be smoothed

#136 

## How Has This Been Tested?

- CI tests
- added a test
- ran locally for ruvnl

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
