### PR TITLE
Add check for ECMWF

### DIFF
--- a/india_forecast_app/models/pvnet/utils.py
+++ b/india_forecast_app/models/pvnet/utils.py
@@ -113,8 +113,9 @@ def process_and_cache_nwp(source_nwp_path: str, dest_nwp_path: str):
             ds[v].encoding.clear()
 
     is_gfs = "gfs" in source_nwp_path.lower()
+    is_ecmwf = "ecmwf" in source_nwp_path.lower()
 
-    if not is_gfs:  # this is for ECMWF NWP
+    if is_ecmwf:
         # Rename t variable to t2m
         variables = list(ds.variable.values)
         new_variables = []


### PR DESCRIPTION
# Pull Request

## Description

Add stronger check for whether the NWP is from ECMWF before variable renaming is applied, has caused a bug in live since MO global NWP data was incorrectly having this logic applied to it 