### PR TITLE
Adjuster night time zeros fix

### DIFF
--- a/india_forecast_app/adjuster.py
+++ b/india_forecast_app/adjuster.py
@@ -6,7 +6,13 @@ from typing import Optional
 import pandas as pd
 import pvlib
 from pvsite_datamodel.read import get_site_by_uuid
-from pvsite_datamodel.sqlmodels import ForecastSQL, ForecastValueSQL, GenerationSQL, MLModelSQL
+from pvsite_datamodel.sqlmodels import (
+    ForecastSQL,
+    ForecastValueSQL,
+    GenerationSQL,
+    MLModelSQL,
+    SiteAssetType,
+)
 from sqlalchemy import INT, cast, text
 from sqlalchemy.sql import func
 
@@ -158,7 +164,7 @@ def zero_out_night_time_for_pv(
     # get the site
     site = get_site_by_uuid(db_session, site_uuid)
 
-    if site.asset_type == "pv":
+    if site.asset_type == SiteAssetType.pv:
 
         longitude = site.longitude
         latitude = site.latitude

--- a/tests/test_adjuster.py
+++ b/tests/test_adjuster.py
@@ -4,6 +4,8 @@ from datetime import datetime
 import pandas as pd
 import pytest
 
+from pvsite_datamodel.sqlmodels import SiteAssetType
+
 from india_forecast_app.adjuster import (
     adjust_forecast_with_adjuster,
     get_me_values,
@@ -80,6 +82,9 @@ def test_adjust_forecast_with_adjuster(db_session, sites, generation_db_values, 
         {
             "forecast_power_kw": [1, 2, 3, 4, 5],
             "horizon_minutes": [15, 30, 45, 60, 1200],
+            "start_utc": [
+                pd.Timestamp("2024-11-01 03:00:00") + pd.Timedelta(f"{i}H") for i in range(0, 5)
+            ],
         }
     )
 
@@ -100,6 +105,9 @@ def test_adjust_forecast_with_adjuster_no_values(db_session, sites):
         {
             "forecast_power_kw": [1, 2, 3, 4, 5],
             "horizon_minutes": [15, 30, 45, 60, 1200],
+            "start_utc": [
+                pd.Timestamp("2024-11-01 03:00:00") + pd.Timedelta(f"{i}H") for i in range(0, 5)
+            ],
         }
     )
 
@@ -111,7 +119,7 @@ def test_adjust_forecast_with_adjuster_no_values(db_session, sites):
     assert forecast_values_df["forecast_power_kw"].sum() == 15
 
 
-@pytest.mark.parametrize("asset_type", ["pv", "wind"])
+@pytest.mark.parametrize("asset_type", [SiteAssetType.pv, SiteAssetType.wind])
 def test_zero_out_night_time_for_pv(asset_type, db_session, sites):
     """ Test for zero_out_nighttime """
     forecast_values_df = pd.DataFrame(
@@ -132,7 +140,7 @@ def test_zero_out_night_time_for_pv(asset_type, db_session, sites):
 
     assert len(forecast_values_df) == 5
     night_sum = forecast_values_df["forecast_power_kw"][0:2].sum()
-    if asset_type == "pv":
+    if asset_type == SiteAssetType.pv:
         assert night_sum == 0
     else:
         assert night_sum > 0

--- a/tests/test_adjuster.py
+++ b/tests/test_adjuster.py
@@ -3,7 +3,6 @@ from datetime import datetime
 
 import pandas as pd
 import pytest
-
 from pvsite_datamodel.sqlmodels import SiteAssetType
 
 from india_forecast_app.adjuster import (


### PR DESCRIPTION
# Pull Request

## Description

make sure adjuster for filtering night zeros is SiteAssetType

#147 

Changes from


<img width="832" alt="Screenshot 2024-12-01 at 18 08 20" src="https://github.com/user-attachments/assets/408d70f4-dfc3-4d06-baff-a95da12a8f36">

to

<img width="659" alt="Screenshot 2024-12-01 at 18 09 11" src="https://github.com/user-attachments/assets/aa38ddee-482a-4091-a63c-2b51b4cf22dc">


## How Has This Been Tested?

CI tests

- [x] Yes
## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
