### PR TITLE
feat: implement automatic location name sanitization and dynamic ener…

### DIFF
--- a/india_forecast_app/save/data_platform.py
+++ b/india_forecast_app/save/data_platform.py
@@ -7,6 +7,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 from collections.abc import AsyncIterator  # noqa: TC003
 from datetime import UTC, datetime, timedelta
 from importlib.metadata import version
@@ -91,13 +92,18 @@ async def save_to_dataplatform(
     if not client_location_name:
         log.error("client_location_name is None/empty — cannot save")
         raise ValueError("client_location_name is required to save to the Data Platform")
+    # DP requires: lowercase, alphanumeric and underscores only (2-100 chars)
+    # Lowercase first, then replace any invalid character with '_'
+    client_location_name = re.sub(r"[^a-z0-9_]", "_", client_location_name.lower())
 
     model_tag = ml_model_name if ml_model_name else "default-model"
     init_time_utc = ensure_timezone_aware(forecast_meta["timestamp_utc"])
     capacity_kw = forecast_meta.get("capacity_kw")
     latitude = forecast_meta.get("latitude")
     longitude = forecast_meta.get("longitude")
-    location_type = forecast_meta.get("location_type", dp.LocationType.SITE)
+    location_type = forecast_meta.get("location_type") or dp.LocationType.SITE
+    # Derive energy source from model name: windnet_* models → WIND, everything else → SOLAR
+    energy_source = dp.EnergySource.WIND if "wind" in model_tag.lower() else dp.EnergySource.SOLAR
 
     log.info(
         "Starting DP save | "
@@ -131,12 +137,19 @@ async def save_to_dataplatform(
                 longitude,
                 init_time_utc,
                 location_type=location_type,
+                energy_source=energy_source,
             )
             log.info(f"created location uuid={target_uuid_str}")
+            # Keep the shared map fresh so subsequent sites in this run don't retry creation
+            location_map[client_location_name] = target_uuid_str
         else:
             log.info(f"location already exists uuid={target_uuid_str}")
 
-        capacity_watts = await get_location_capacity(client=client, target_uuid_str=target_uuid_str)
+        capacity_watts = await get_location_capacity(
+            client=client,
+            target_uuid_str=target_uuid_str,
+            energy_source=energy_source,
+        )
         log.info(
             f"capacity_watts={capacity_watts:,}  ({capacity_watts / 1000:,.1f} kW)",
         )
@@ -170,7 +183,7 @@ async def save_to_dataplatform(
         base_request = dp.CreateForecastRequest(
             forecaster=forecaster,
             location_uuid=target_uuid_str,
-            energy_source=dp.EnergySource.SOLAR,
+            energy_source=energy_source,
             init_time_utc=init_time_utc,
             values=forecast_values,
             metadata=Struct(fields={"app_version": Value(string_value=app_version)}),
@@ -193,6 +206,7 @@ async def save_to_dataplatform(
                 forecast_values=forecast_values,
                 model_tag=model_tag,
                 forecaster=forecaster,
+                energy_source=energy_source,
             )
             await client.create_forecast(adjusted_request)
             log.info(f"Adjusted forecast submitted for {client_location_name!r}")
@@ -207,6 +221,7 @@ async def make_forecaster_adjuster(
     forecast_values: list[dp.CreateForecastRequestForecastValue],
     model_tag: str,
     forecaster: dp.Forecaster,
+    energy_source: dp.EnergySource = dp.EnergySource.SOLAR,
 ) -> dp.CreateForecastRequest:
     """Build an adjusted forecast request using week-average deltas from the Data Platform.
 
@@ -227,7 +242,7 @@ async def make_forecaster_adjuster(
     """
     deltas_request = dp.GetWeekAverageDeltasRequest(
         location_uuid=location_uuid,
-        energy_source=dp.EnergySource.SOLAR,
+        energy_source=energy_source,
         pivot_timestamp_utc=init_time_utc.replace(tzinfo=UTC),
         forecaster=forecaster,
         observer_name=os.getenv("OBSERVER_NAME", "india"),
@@ -242,7 +257,7 @@ async def make_forecaster_adjuster(
     location = await client.get_location(
         dp.GetLocationRequest(
             location_uuid=location_uuid,
-            energy_source=dp.EnergySource.SOLAR,
+            energy_source=energy_source,
             include_geometry=False,
         ),
     )
@@ -279,7 +294,7 @@ async def make_forecaster_adjuster(
     return dp.CreateForecastRequest(
         forecaster=adjuster_forecaster,
         location_uuid=location_uuid,
-        energy_source=dp.EnergySource.SOLAR,
+        energy_source=energy_source,
         init_time_utc=init_time_utc.replace(tzinfo=UTC),
         values=adjusted_values,
     )
@@ -315,12 +330,13 @@ async def resolve_target_uuid(
 async def get_location_capacity(
     client: DataPlatformClient,
     target_uuid_str: str,
+    energy_source: dp.EnergySource = dp.EnergySource.SOLAR,
 ) -> int:
     """Fetch effective capacity (watts) for an existing DP location."""
     location = await client.get_location(
         dp.GetLocationRequest(
             location_uuid=target_uuid_str,
-            energy_source=dp.EnergySource.SOLAR,
+            energy_source=energy_source,
             include_geometry=False,
         ),
     )
@@ -335,6 +351,7 @@ async def create_new_location(
     longitude: float | None,
     init_time_utc: datetime,
     location_type: dp.LocationType = dp.LocationType.SITE,
+    energy_source: dp.EnergySource = dp.EnergySource.SOLAR,
 ) -> str:
     """Create a new location in the Data Platform and return its UUID."""
     log.warning(
@@ -349,7 +366,7 @@ async def create_new_location(
     try:
         create_req = dp.CreateLocationRequest(
             location_name=client_location_name,
-            energy_source=dp.EnergySource.SOLAR,
+            energy_source=energy_source,
             geometry_wkt=wkt,
             effective_capacity_watts=capacity_watts,
             location_type=location_type,

--- a/india_forecast_app/save/data_platform.py
+++ b/india_forecast_app/save/data_platform.py
@@ -236,6 +236,7 @@ async def make_forecaster_adjuster(
         forecast_values: Base forecast values to adjust.
         model_tag: Model name used to look up/create the adjuster forecaster.
         forecaster: The base forecaster object (used to fetch deltas).
+        energy_source: Energy source type (e.g. SOLAR or WIND).
 
     Returns:
         A ``CreateForecastRequest`` for the adjusted forecast.

--- a/tests/save/test_save_data_platform.py
+++ b/tests/save/test_save_data_platform.py
@@ -19,6 +19,13 @@ Tests cover:
 15. save_to_dataplatform: zero capacity returns early without creating forecast
 16. save_to_dataplatform: missing client_location_name raises ValueError
 17. save_to_dataplatform: existing location is reused without calling create_location
+18. save_to_dataplatform: uppercase location name is lowercased before DP call
+19. save_to_dataplatform: hyphen in location name is replaced with underscore
+20. save_to_dataplatform: mixed invalid chars in location name are all sanitised
+21. save_to_dataplatform: windnet model tag routes to EnergySource.WIND
+22. save_to_dataplatform: pvnet model tag routes to EnergySource.SOLAR
+23. save_to_dataplatform: location_map is updated in-place after new location is created
+24. create_new_location: gRPC error propagates immediately without retry
 """
 
 from __future__ import annotations
@@ -28,10 +35,14 @@ import datetime as dt
 from datetime import UTC
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import ocf.dp as dp_mod
 import pandas as pd
 import pytest
+from grpclib.const import Status
+from grpclib.exceptions import GRPCError
 
 from india_forecast_app.save.data_platform import (
+    create_new_location,
     fetch_dp_location_map,
     prepare_forecast_values,
     resolve_target_uuid,
@@ -265,6 +276,7 @@ class TestSaveToDataplatform:
                 forecast_df=df,
                 forecast_meta=forecast_meta,
                 ml_model_name="test-model",
+                location_map={},
                 use_adjuster=True,
             )
         )
@@ -285,6 +297,7 @@ class TestSaveToDataplatform:
                 forecast_df=df,
                 forecast_meta=forecast_meta,
                 ml_model_name="test-model",
+                location_map={},
             )
         )
         
@@ -308,10 +321,12 @@ class TestSaveToDataplatform:
                 forecast_df=df,
                 forecast_meta=forecast_meta,
                 ml_model_name="test-model",
+                location_map={},
                 use_adjuster=False,
             )
         )
         
+        # Should NOT have created forecast
         mock_client.create_forecast.assert_not_called()
 
     def test_save_to_dataplatform_missing_location_name(self, mock_get_client):
@@ -329,6 +344,7 @@ class TestSaveToDataplatform:
                     forecast_df=df,
                     forecast_meta=forecast_meta,
                     ml_model_name="test-model",
+                    location_map={},
                 )
             )
 
@@ -357,3 +373,186 @@ class TestSaveToDataplatform:
         mock_client.get_location.assert_called()
         mock_client.create_forecast.assert_called_once()
 
+
+class TestLocationNameNormalisation:
+    """[18-20] client_location_name is sanitised to lowercase + underscores before any DP call."""
+
+    @pytest.fixture
+    def mock_get_client(self):
+        """Mock get_dataplatform_client for location name normalisation tests."""
+        with patch("india_forecast_app.save.data_platform.get_dataplatform_client") as m:
+            mock_cm = AsyncMock()
+            mock_client = AsyncMock()
+            mock_cm.__aenter__.return_value = mock_client
+            m.return_value = mock_cm
+            mock_client.list_locations.return_value = MagicMock(locations=[])
+            mock_client.create_location.return_value = MagicMock(location_uuid="new-uuid")
+            mock_client.get_location.return_value = MagicMock(effective_capacity_watts=5_000_000)
+            mock_client.list_forecasters.return_value = MagicMock(forecasters=[])
+            mock_client.create_forecaster.return_value = MagicMock(
+                forecaster=MagicMock(forecaster_name="pvnet_india", forecaster_version="1.4.0")
+            )
+            mock_client.create_forecast.return_value = MagicMock()
+            mock_client.get_week_average_deltas.return_value = MagicMock(deltas=[])
+            yield mock_client
+
+    def _run_save(self, mock_client, location_name: str, model_name: str = "pvnet_india"):
+        """Helper to invoke save_to_dataplatform with a given location name."""
+        asyncio.run(
+            save_to_dataplatform(
+                forecast_df=_make_forecast_values_df(n=2),
+                forecast_meta={
+                    "client_location_name": location_name,
+                    "timestamp_utc": dt.datetime(2024, 6, 1, 12, 0, tzinfo=UTC),
+                    "capacity_kw": 5.0,
+                },
+                ml_model_name=model_name,
+                location_map={},
+                use_adjuster=False,
+            )
+        )
+
+    def test_uppercase_is_lowercased(self, mock_get_client):
+        """[18] Uppercase letters in location name are lowercased before DP call."""
+        self._run_save(mock_get_client, "ad_Seci_5")
+
+        req = mock_get_client.create_location.call_args[0][0]
+        assert req.location_name == "ad_seci_5"
+
+    def test_hyphen_replaced_with_underscore(self, mock_get_client):
+        """[19] Hyphens in location name are replaced with underscores."""
+        self._run_save(mock_get_client, "ad_aeml-1")
+
+        req = mock_get_client.create_location.call_args[0][0]
+        assert req.location_name == "ad_aeml_1"
+
+    def test_mixed_invalid_chars_sanitised(self, mock_get_client):
+        """[20] Mixed invalid chars (spaces, dots, hyphens, uppercase) are all sanitised."""
+        self._run_save(mock_get_client, "Site.Name-X 2")
+
+        req = mock_get_client.create_location.call_args[0][0]
+        assert req.location_name == "site_name_x_2"
+
+
+class TestEnergySourceFromModelTag:
+    """[21-22] energy_source is derived from model_tag: windnet_* -> WIND, else -> SOLAR."""
+
+    @pytest.fixture
+    def mock_get_client(self):
+        """Mock get_dataplatform_client for energy source routing tests."""
+        with patch("india_forecast_app.save.data_platform.get_dataplatform_client") as m:
+            mock_cm = AsyncMock()
+            mock_client = AsyncMock()
+            mock_cm.__aenter__.return_value = mock_client
+            m.return_value = mock_cm
+            mock_client.list_locations.return_value = MagicMock(locations=[])
+            mock_client.create_location.return_value = MagicMock(location_uuid="uuid-x")
+            mock_client.get_location.return_value = MagicMock(effective_capacity_watts=5_000_000)
+            mock_client.list_forecasters.return_value = MagicMock(forecasters=[])
+            mock_client.create_forecaster.return_value = MagicMock(
+                forecaster=MagicMock(forecaster_name="model", forecaster_version="1.4.0")
+            )
+            mock_client.create_forecast.return_value = MagicMock()
+            mock_client.get_week_average_deltas.return_value = MagicMock(deltas=[])
+            yield mock_client
+
+    def test_windnet_model_uses_wind_energy_source(self, mock_get_client):
+        """[21] windnet_* model tag -> EnergySource.WIND in create_location."""
+        asyncio.run(
+            save_to_dataplatform(
+                forecast_df=_make_forecast_values_df(n=2),
+                forecast_meta={
+                    "client_location_name": "test_loc",
+                    "timestamp_utc": dt.datetime(2024, 6, 1, 12, tzinfo=UTC),
+                    "capacity_kw": 5.0,
+                },
+                ml_model_name="windnet_india",
+                location_map={},
+                use_adjuster=False,
+            )
+        )
+
+        req = mock_get_client.create_location.call_args[0][0]
+        assert req.energy_source == dp_mod.EnergySource.WIND
+
+    def test_pvnet_model_uses_solar_energy_source(self, mock_get_client):
+        """[22] pvnet_* model tag -> EnergySource.SOLAR in create_location."""
+        asyncio.run(
+            save_to_dataplatform(
+                forecast_df=_make_forecast_values_df(n=2),
+                forecast_meta={
+                    "client_location_name": "test_loc",
+                    "timestamp_utc": dt.datetime(2024, 6, 1, 12, tzinfo=UTC),
+                    "capacity_kw": 5.0,
+                },
+                ml_model_name="pvnet_india",
+                location_map={},
+                use_adjuster=False,
+            )
+        )
+
+        req = mock_get_client.create_location.call_args[0][0]
+        assert req.energy_source == dp_mod.EnergySource.SOLAR
+
+
+class TestLocationMapUpdatedAfterCreation:
+    """[23] location_map dict is updated in-place after a new location is created."""
+
+    def test_location_map_updated_after_new_location_created(self):
+        """[23] After creating a new location, its name->UUID is added to location_map."""
+        location_map: dict[str, str] = {}
+
+        with patch("india_forecast_app.save.data_platform.get_dataplatform_client") as m:
+            mock_cm = AsyncMock()
+            mock_client = AsyncMock()
+            mock_cm.__aenter__.return_value = mock_client
+            m.return_value = mock_cm
+            mock_client.list_locations.return_value = MagicMock(locations=[])
+            mock_client.create_location.return_value = MagicMock(location_uuid="created-uuid-abc")
+            mock_client.get_location.return_value = MagicMock(effective_capacity_watts=5_000_000)
+            mock_client.list_forecasters.return_value = MagicMock(forecasters=[])
+            mock_client.create_forecaster.return_value = MagicMock(
+                forecaster=MagicMock(forecaster_name="pvnet_india", forecaster_version="1.4.0")
+            )
+            mock_client.create_forecast.return_value = MagicMock()
+            mock_client.get_week_average_deltas.return_value = MagicMock(deltas=[])
+
+            asyncio.run(
+                save_to_dataplatform(
+                    forecast_df=_make_forecast_values_df(n=2),
+                    forecast_meta={
+                        "client_location_name": "brand_new_site",
+                        "timestamp_utc": dt.datetime(2024, 6, 1, 12, tzinfo=UTC),
+                        "capacity_kw": 5.0,
+                    },
+                    ml_model_name="pvnet_india",
+                    location_map=location_map,
+                    use_adjuster=False,
+                )
+            )
+
+        assert "brand_new_site" in location_map
+        assert location_map["brand_new_site"] == "created-uuid-abc"
+
+
+class TestCreateNewLocationFailure:
+    """[24] create_new_location raises immediately on DP error without retry."""
+
+    def test_create_location_failure_raises(self):
+        """[24] A gRPC error from create_location propagates directly."""
+        mock_client = AsyncMock()
+        mock_client.create_location.side_effect = GRPCError(
+            Status.INVALID_ARGUMENT, "bad request", None
+        )
+
+        with pytest.raises(GRPCError):
+            asyncio.run(
+                create_new_location(
+                    client=mock_client,
+                    client_location_name="failing_site",
+                    capacity_kw=100.0,
+                    latitude=20.0,
+                    longitude=78.0,
+                    init_time_utc=dt.datetime(2024, 6, 1, tzinfo=UTC),
+                )
+            )


### PR DESCRIPTION
# Pull Request

## Description

This PR implements automatic location name sanitization and dynamic energy source detection based on the ML model name when saving forecasts to the Data Platform.

### Key Changes:
1. **Location Name Sanitization**: Automatically normalizes client location names to lowercase and replaces invalid characters (such as spaces, dots, and hyphens) with underscores (`_`) using regular expressions to conform to Data Platform naming requirements.
2. **Dynamic Energy Source Selection**: Derives the energy source (`WIND` or `SOLAR`) based on the ML model tag (e.g., tags containing `"wind"` map to `WIND`, while other tags default to `SOLAR`), and propagates it correctly across location lookup/creation, capacity checks, and forecast submissions.
3. **In-place Location Map Updates**: Ensures newly created locations are added to the shared `location_map` to prevent subsequent sites from triggering redundant location lookup or creation calls in the same run.

Fixes #

## How Has This Been Tested?

The changes have been validated by adding comprehensive tests to `tests/save/test_save_data_platform.py` and running the suite:
- `uv run pytest tests/save/test_save_data_platform.py`
-  This has been tested for both adani and ruvnl against dev DP

Test coverage includes:
- Verification of uppercase, hyphenated, and mixed invalid character sanitization.
- Verification that `windnet_*` models correctly map to `WIND` and other models default to `SOLAR`.
- Verification that `location_map` updates correctly in-place when a new location is created.


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
