### PR TITLE
feat: add dp_location_name to models and update saving logic for forecasts

### DIFF
--- a/india_forecast_app/app.py
+++ b/india_forecast_app/app.py
@@ -235,6 +235,9 @@ def app_run(timestamp: dt.datetime | None, write_to_db: bool = False, log_level:
                             "capacity_kw": site.capacity_kw,
                             "latitude": site.latitude,
                             "longitude": site.longitude,
+                            "asset_type": model_config.asset_type,
+                            "location_type": model_config.location_type,
+                            "dp_location_name": model_config.dp_location_name,
                         },
                         "values": forecast_values,
                     }

--- a/india_forecast_app/models/all_models.yaml
+++ b/india_forecast_app/models/all_models.yaml
@@ -7,24 +7,32 @@ models:
     version: ae07c15de064e1d03cf4bc02618b65c6d5b17e8e
     client: ruvnl
     asset_type: wind
+    location_type: state
+    dp_location_name: ruvnl_wind
   - name: windnet_india_mo
     type: pvnet
     id: openclimatefix-models/windnet_india
     version: 546baded3d4216736d8ee8d6798d47235bd72b08
     client: ruvnl
     asset_type: wind
+    location_type: state
+    dp_location_name: ruvnl_wind
   - name: windnet_india_mo_v2
     type: pvnet
     id: openclimatefix-models/windnet_india
     version: 165267d34500cf0c881ed70d9318421f4e0d10f1
     client: ruvnl
     asset_type: wind
+    location_type: state
+    dp_location_name: ruvnl_wind
   - name: windnet_india_mo_v3
     type: pvnet
     id: openclimatefix-models/windnet_india
     version: 990bed9ad1dbb10515f830c181609b10e72c975e
     client: ruvnl
     asset_type: wind
+    location_type: state
+    dp_location_name: ruvnl_wind
    # RU client solar
   - name: pvnet_india
     type: pvnet
@@ -32,12 +40,16 @@ models:
     version: d71104620f0b0bdd3eeb63cafecd2a49032ae0f7
     client: ruvnl
     asset_type: pv
+    location_type: state
+    dp_location_name: ruvnl_solar
   - name: pvnet_india_ecmwf_mo_gfs
     type: pvnet
     id: openclimatefix-models/pvnet_india
     version: 7a179d1f8349d99cb2a30a48e5be17d59b6f2b16
     client: ruvnl
     asset_type: pv
+    location_type: state
+    dp_location_name: ruvnl_solar
 # Ad client wind
   - name: windnet_ad_sites
     type: pvnet

--- a/india_forecast_app/models/pydantic_models.py
+++ b/india_forecast_app/models/pydantic_models.py
@@ -1,6 +1,6 @@
 """ A pydantic model for the ML models"""
 
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 import fsspec
 from pyaml_env import parse_config
@@ -35,6 +35,19 @@ class Model(BaseModel):
                     "calculating adjuster values. "
                     "For solar site with regular data, 15 should be used. "
                     "For wind sites, 60 minutes should be used.",
+    )
+    location_type: Literal["site", "state", "nation"] = Field(
+        "site",
+        title="Location Type",
+        description="The Data Platform location type that forecasts are saved to. "
+                    "Regional aggregate forecasts (e.g. RUVNL) should use 'state', "
+                    "individual plants should use 'site'.",
+    )
+    dp_location_name: Optional[str] = Field(
+        None,
+        title="Data Platform Location Name",
+        description="The Data Platform location that forecasts are saved to. "
+                    "When unset, the site's client_location_name is used.",
     )
 
 

--- a/india_forecast_app/save/data_platform.py
+++ b/india_forecast_app/save/data_platform.py
@@ -25,6 +25,21 @@ from india_forecast_app.save.utils import (
 
 log = logging.getLogger(__name__)
 
+_DP_LOCATION_TYPES = {
+    "site": dp.LocationType.SITE,
+    "state": dp.LocationType.STATE,
+    "nation": dp.LocationType.NATION,
+}
+
+
+def to_dp_location_type(location_type: dp.LocationType | str | None) -> dp.LocationType:
+    """Convert a model-config location type ("site"/"state"/"nation") to the DP enum."""
+    if location_type is None or location_type == "":
+        return dp.LocationType.SITE
+    if isinstance(location_type, dp.LocationType):
+        return location_type
+    return _DP_LOCATION_TYPES[str(location_type).lower()]
+
 # -- Version --
 # we need to keep this static so that the adjust and api works,
 # even if we change version
@@ -88,7 +103,11 @@ async def save_to_dataplatform(
         log.warning("forecast dataframe is empty")
         return
 
-    client_location_name = forecast_meta.get("client_location_name")
+    # The model config can pin the DP location to save to (e.g. the ruvnl_solar state
+    # location); otherwise the site's client_location_name is used
+    client_location_name = (
+        forecast_meta.get("dp_location_name") or forecast_meta.get("client_location_name")
+    )
     if not client_location_name:
         log.error("client_location_name is None/empty — cannot save")
         raise ValueError("client_location_name is required to save to the Data Platform")
@@ -101,9 +120,18 @@ async def save_to_dataplatform(
     capacity_kw = forecast_meta.get("capacity_kw")
     latitude = forecast_meta.get("latitude")
     longitude = forecast_meta.get("longitude")
-    location_type = forecast_meta.get("location_type") or dp.LocationType.SITE
-    # Derive energy source from model name: windnet_* models → WIND, everything else → SOLAR
-    energy_source = dp.EnergySource.WIND if "wind" in model_tag.lower() else dp.EnergySource.SOLAR
+    location_type = to_dp_location_type(forecast_meta.get("location_type"))
+    # Prefer the site's asset type; fall back to deriving from the model name
+    # (windnet_* models → WIND, everything else → SOLAR)
+    asset_type = forecast_meta.get("asset_type")
+    if asset_type:
+        energy_source = (
+            dp.EnergySource.WIND if str(asset_type).lower() == "wind" else dp.EnergySource.SOLAR
+        )
+    else:
+        energy_source = (
+            dp.EnergySource.WIND if "wind" in model_tag.lower() else dp.EnergySource.SOLAR
+        )
 
     log.info(
         "Starting DP save | "

--- a/india_forecast_app/save/save.py
+++ b/india_forecast_app/save/save.py
@@ -53,6 +53,8 @@ def save_forecast(
         "latitude": forecast["meta"].get("latitude"),
         "longitude": forecast["meta"].get("longitude"),
         "location_type": forecast["meta"].get("location_type"),
+        "asset_type": forecast["meta"].get("asset_type"),
+        "dp_location_name": forecast["meta"].get("dp_location_name"),
     }
 
     # Only the fields ForecastSQL accepts — extra keys cause a TypeError via **forecast_meta

--- a/tests/save/test_save_data_platform.py
+++ b/tests/save/test_save_data_platform.py
@@ -26,6 +26,9 @@ Tests cover:
 22. save_to_dataplatform: pvnet model tag routes to EnergySource.SOLAR
 23. save_to_dataplatform: location_map is updated in-place after new location is created
 24. create_new_location: gRPC error propagates immediately without retry
+25. save_to_dataplatform: dp_location_name in meta overrides client_location_name
+26. save_to_dataplatform: location_type "state" string maps to LocationType.STATE
+27. save_to_dataplatform: asset_type in meta takes precedence over the model tag
 """
 
 from __future__ import annotations
@@ -556,3 +559,81 @@ class TestCreateNewLocationFailure:
                     init_time_utc=dt.datetime(2024, 6, 1, tzinfo=UTC),
                 )
             )
+
+class TestModelConfigTargeting:
+    """[25-27] Model-config driven targeting: dp_location_name, location_type, asset_type."""
+
+    @pytest.fixture
+    def mock_get_client(self):
+        """Mock get_dataplatform_client for model-config targeting tests."""
+        with patch("india_forecast_app.save.data_platform.get_dataplatform_client") as m:
+            mock_cm = AsyncMock()
+            mock_client = AsyncMock()
+            mock_cm.__aenter__.return_value = mock_client
+            m.return_value = mock_cm
+            mock_client.list_locations.return_value = MagicMock(locations=[])
+            mock_client.create_location.return_value = MagicMock(location_uuid="uuid-x")
+            mock_client.get_location.return_value = MagicMock(effective_capacity_watts=5_000_000)
+            mock_client.list_forecasters.return_value = MagicMock(forecasters=[])
+            mock_client.create_forecaster.return_value = MagicMock(
+                forecaster=MagicMock(forecaster_name="model", forecaster_version="1.4.0")
+            )
+            mock_client.create_forecast.return_value = MagicMock()
+            yield mock_client
+
+    def _run_save(self, forecast_meta: dict, location_map: dict, model_name: str = "pvnet_india"):
+        """Helper to invoke save_to_dataplatform with a given forecast_meta."""
+        asyncio.run(
+            save_to_dataplatform(
+                forecast_df=_make_forecast_values_df(n=2),
+                forecast_meta={
+                    "timestamp_utc": dt.datetime(2024, 6, 1, 12, tzinfo=UTC),
+                    "capacity_kw": 5.0,
+                    **forecast_meta,
+                },
+                ml_model_name=model_name,
+                location_map=location_map,
+                use_adjuster=False,
+            )
+        )
+
+    def test_dp_location_name_overrides_client_location_name(self, mock_get_client):
+        """[25] dp_location_name resolves to the existing DP location, not the site name."""
+        self._run_save(
+            forecast_meta={
+                "client_location_name": "ruvnl_solar_site",
+                "dp_location_name": "ruvnl_solar",
+            },
+            location_map={"ruvnl_solar": "uuid-solar-state"},
+        )
+
+        mock_get_client.create_location.assert_not_called()
+        req = mock_get_client.create_forecast.call_args[0][0]
+        assert req.location_uuid == "uuid-solar-state"
+
+    def test_location_type_state_string_converted(self, mock_get_client):
+        """[26] location_type "state" from the model config maps to LocationType.STATE."""
+        self._run_save(
+            forecast_meta={
+                "client_location_name": "ruvnl_solar",
+                "location_type": "state",
+            },
+            location_map={},
+        )
+
+        req = mock_get_client.create_location.call_args[0][0]
+        assert req.location_type == dp_mod.LocationType.STATE
+
+    def test_asset_type_takes_precedence_over_model_tag(self, mock_get_client):
+        """[27] asset_type "wind" gives EnergySource.WIND even for a non-windnet model tag."""
+        self._run_save(
+            forecast_meta={
+                "client_location_name": "test_loc",
+                "asset_type": "wind",
+            },
+            location_map={},
+            model_name="pvnet_india",
+        )
+
+        req = mock_get_client.create_location.call_args[0][0]
+        assert req.energy_source == dp_mod.EnergySource.WIND


### PR DESCRIPTION
# Pull Request

## Description

- added dp_location_name to models
- added test
- with this, we can save the forecasts to a certain location

Fixes #https://github.com/openclimatefix/client-private/issues/546

## How Has This Been Tested?

- [x] with dev data-platform

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
